### PR TITLE
Fix ruler text-alignment

### DIFF
--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -2080,11 +2080,22 @@ pub(super) fn rulers_at_value(
     };
 
     let font_id = TextStyle::Body.resolve(plot.ui.style());
+    let rect = plot.transform.frame();
+    let bottom_align = pointer.y > (rect.min.y + 100.0);
+    let left_align = pointer.x >= (rect.min.x + 100.0);
+
+    let align = match (left_align, bottom_align) {
+        (false, true) => Align2::LEFT_BOTTOM,
+        (false, false) => Align2::LEFT_TOP,
+        (true, true) => Align2::RIGHT_BOTTOM,
+        (true, false) => Align2::RIGHT_TOP,
+    };
+
     plot.ui.fonts(|f| {
         shapes.push(Shape::text(
             f,
             pointer + vec2(3.0, -2.0),
-            Align2::LEFT_BOTTOM,
+            align,
             text,
             font_id,
             plot.ui.visuals().text_color(),


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

This fixes the issue, that sometimes the rulertext is not shown when hovering near the borders of the plot

* Closes <https://github.com/emilk/egui_plot/issues/30>
* [x] I have followed the instructions in the PR template
