### PR TITLE
Add Legend Formatter support

### DIFF
--- a/egui_plot/src/legend.rs
+++ b/egui_plot/src/legend.rs
@@ -6,6 +6,7 @@ use egui::{
 };
 
 use super::items::PlotItem;
+use super::LegendFormatterFn;
 
 /// Where to place the plot legend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -192,6 +193,7 @@ impl LegendWidget {
         config: Legend,
         items: &[Box<dyn PlotItem>],
         hidden_items: &ahash::HashSet<String>, // Existing hidden items in the plot memory.
+        formatter: Option<&LegendFormatterFn>,
     ) -> Option<Self> {
         // If `config.hidden_items` is not `None`, it is used.
         let hidden_items = config.hidden_items.as_ref().unwrap_or(hidden_items);
@@ -203,8 +205,12 @@ impl LegendWidget {
             .iter()
             .filter(|item| !item.name().is_empty())
             .for_each(|item| {
+                let name = formatter.map_or_else(
+                    || item.name().to_owned(),
+                    |formatter| formatter(item.name()).to_owned(),
+                );
                 entries
-                    .entry(item.name().to_owned())
+                    .entry(name.clone())
                     .and_modify(|entry| {
                         if entry.color != item.color() {
                             // Multiple items with different colors
@@ -213,7 +219,7 @@ impl LegendWidget {
                     })
                     .or_insert_with(|| {
                         let color = item.color();
-                        let checked = !hidden_items.contains(item.name());
+                        let checked = !hidden_items.contains(&name);
                         LegendEntry::new(color, checked)
                     });
             });

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -45,6 +45,9 @@ use legend::LegendWidget;
 type LabelFormatterFn<'a> = dyn Fn(&str, &PlotPoint) -> String + 'a;
 pub type LabelFormatter<'a> = Option<Box<LabelFormatterFn<'a>>>;
 
+type LegendFormatterFn = dyn Fn(&str) -> &str;
+type LegendFormatter = Option<Box<LegendFormatterFn>>;
+
 type GridSpacerFn<'a> = dyn Fn(GridInput) -> Vec<GridMark> + 'a;
 type GridSpacer<'a> = Box<GridSpacerFn<'a>>;
 
@@ -176,6 +179,7 @@ pub struct Plot<'a> {
     show_x: bool,
     show_y: bool,
     label_formatter: LabelFormatter<'a>,
+    legend_formatter: LegendFormatter,
     coordinates_formatter: Option<(Corner, CoordinatesFormatter<'a>)>,
     x_axes: Vec<AxisHints<'a>>, // default x axes
     y_axes: Vec<AxisHints<'a>>, // default y axes
@@ -223,6 +227,7 @@ impl<'a> Plot<'a> {
             show_x: true,
             show_y: true,
             label_formatter: None,
+            legend_formatter: None,
             coordinates_formatter: None,
             x_axes: vec![AxisHints::new(Axis::X)],
             y_axes: vec![AxisHints::new(Axis::Y)],
@@ -413,6 +418,15 @@ impl<'a> Plot<'a> {
         label_formatter: impl Fn(&str, &PlotPoint) -> String + 'a,
     ) -> Self {
         self.label_formatter = Some(Box::new(label_formatter));
+        self
+    }
+
+    /// Provide a function to customize the legend labels
+    ///
+    /// All items with the same name will be shown with (and have their visibility controlled by) a single label
+    #[inline]
+    pub fn legend_formatter(mut self, legend_formatter: impl Fn(&str) -> &str + 'static) -> Self {
+        self.legend_formatter = Some(Box::new(legend_formatter));
         self
     }
 
@@ -764,6 +778,7 @@ impl<'a> Plot<'a> {
             mut show_x,
             mut show_y,
             label_formatter,
+            legend_formatter,
             coordinates_formatter,
             x_axes,
             y_axes,
@@ -893,20 +908,40 @@ impl<'a> Plot<'a> {
         }
 
         // --- Legend ---
-        let legend = legend_config
-            .and_then(|config| LegendWidget::try_new(plot_rect, config, &items, &mem.hidden_items));
+        let legend = legend_config.and_then(|config| {
+            LegendWidget::try_new(
+                plot_rect,
+                config,
+                &items,
+                &mem.hidden_items,
+                legend_formatter
+                    .as_ref()
+                    .map(|formatter| formatter.as_ref()),
+            )
+        });
         // Don't show hover cursor when hovering over legend.
         if mem.hovered_legend_item.is_some() {
             show_x = false;
             show_y = false;
         }
         // Remove the deselected items.
-        items.retain(|item| !mem.hidden_items.contains(item.name()));
+        items.retain(|item| {
+            !mem.hidden_items.contains(
+                legend_formatter
+                    .as_ref()
+                    .map_or_else(|| item.name(), |formatter| formatter(item.name())),
+            )
+        });
         // Highlight the hovered items.
         if let Some(hovered_name) = &mem.hovered_legend_item {
             items
                 .iter_mut()
-                .filter(|entry| entry.name() == hovered_name)
+                .filter(|entry| {
+                    legend_formatter
+                        .as_ref()
+                        .map_or_else(|| entry.name(), |formatter| formatter(entry.name()))
+                        == hovered_name
+                })
                 .for_each(|entry| entry.highlight());
         }
         // Move highlighted items to front.


### PR DESCRIPTION
Original PR in the `egui` repo: https://github.com/emilk/egui/pull/4662

Original PR description:
> Small change to introduce the ability to provide a function which (if provided) will be used to format the text used in the legend.
>
> The motivation for this is to be able to plot enumerated signals in which the specific enum name is included in the name of the point/line (eg. `enum_name::enumeration`). Without this change there is no way (as far as I can tell) to get all of the points/lines into the same entry in the legend, so you end up with a legend entry for each possible enumeration. There may be a better way to accomplish this that I'm not seeing, though.


Additional clarification added as a [comment](https://github.com/emilk/egui/pull/4662#issuecomment-2209527704) in the original PR:

> I think this is reasonable regardless of my usecase, but let me try to give an example. Maybe you will have a better idea.
> 
> Let's say the data I want to plot is represented by an enum:
> 
> ```rust
> enum TestEnum {
>     Val1,
>     Val2,
>     Val3,
>     etc...
> }
> ```
> 
> where each enumeration is mapped to an integer representation (i.e. `Val1` is represented by `1`). Then, each point to plot is effectively a `(Time, (TestEnum, Value))` tuple. The data to plot might look like:
> 
> ```rust
> let data: (u32, (TestEnum, u32)) = vec![
>     (0, (TestEnum::Val1, 1)),
>     (1, (TestEnum::Val1, 1)),
>     (2, (TestEnum::Val2, 2)),
>     (3, (TestEnum::Val3, 3)),
>     (4, (TestEnum::Val4, 4)),
> ]
> ```
> 
> I want to see the enumeration name when hovering over the point, so the way that I have been doing it so far is to create Points with the time and enum value, and then setting the name for each point to a stringified representation of the enumeration.
> 
> This works ok for showing the data on the plot. I would actually prefer if there was a way to change the Y axis from showing floats to the actual enumerations, but it doesn't seem like there's a way to do that (at least that I've found so far).
> 
> The problem is that the points now all have different names (i.e. `TestEnum::Val1`, `TestEnum::Val2`, etc.) so that the names show in the hover, but that results in the legend showing all of the enumerations as different plots. With the `legend_formatter` I've added here, I can just split on the `::` and drop the second part, effectively grouping each of the points into its enum regardless of the specific enumeration.
> 
> Continuing with the above example, the first entry in the `data` vec would result in a Point with time 0 and value 1, with the name `TestEnum::Val1` shown on hover, but it would still show up in the legend under `TestEnum` rather than `TestEnum::Val1` thanks to the modifications performed in the `legend_formatter` function. The rest of the points would then also end up under the `TestEnum` group in the legend.
> 
> Does this make sense? Like I said, there may be a better way to do this. I feel like the real solution (which would address not only this issue, but also the one mentioned above regarding the Y axis) would be to implement a new Widget such as `EnumeratedPlot` which would support y-axes with data types other than floats, and which could also support the legend behavior I'm looking for. That seems like a much bigger task, though, and I feel like this `legend_formatter` could also be beneficial in general.

