### PR TITLE
Allow setting a line's fill area's alpha channel

### DIFF
--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -427,6 +427,7 @@ pub struct Line {
     pub(super) highlight: bool,
     pub(super) allow_hover: bool,
     pub(super) fill: Option<f32>,
+    pub(super) fill_alpha: f32,
     pub(super) style: LineStyle,
     id: Option<Id>,
 }
@@ -440,6 +441,7 @@ impl Line {
             highlight: false,
             allow_hover: true,
             fill: None,
+            fill_alpha: DEFAULT_FILL_ALPHA,
             style: LineStyle::Solid,
             id: None,
         }
@@ -484,6 +486,13 @@ impl Line {
     #[inline]
     pub fn fill(mut self, y_reference: impl Into<f32>) -> Self {
         self.fill = Some(y_reference.into());
+        self
+    }
+
+    /// Set the fill area's alpha channel. Default is `0.05`.
+    #[inline]
+    pub fn fill_alpha(mut self, alpha: impl Into<f32>) -> Self {
+        self.fill_alpha = alpha.into();
         self
     }
 
@@ -545,7 +554,7 @@ impl PlotItem for Line {
             fill = None;
         }
         if let Some(y_reference) = fill {
-            let mut fill_alpha = DEFAULT_FILL_ALPHA;
+            let mut fill_alpha = self.fill_alpha;
             if *highlight {
                 fill_alpha = (2.0 * fill_alpha).at_most(1.0);
             }


### PR DESCRIPTION
Hey! I'm trying to achieve stacked plot lines and came across [Line::fill](https://docs.rs/egui_plot/latest/egui_plot/struct.Line.html#method.fill), which does exactly what I want. The only problem with drawing the fill area is that a user doesn't have control over the alpha channel. As a result, having multiple fill areas within a single plot causes the colors to blend, which is undesired in my case. See the images below:

Current:

![image](https://github.com/user-attachments/assets/d6ece302-662f-44f7-854b-876a40b4b285)

Desired: 

![image](https://github.com/user-attachments/assets/146bdc6d-ca2f-4f0c-b89a-33eb34dd0af1)

This change adds `Line::fill_alpha`, which allows a user to explicitly set the alpha channel used for drawing the fill area. The default value for `fill_alpha` remains the same as before, causing this PR to not be a breaking change.

