### PR TITLE
Add `PlotUi::add_item(Box<dyn PlotItem>)`

### DIFF
--- a/egui_plot/src/plot_ui.rs
+++ b/egui_plot/src/plot_ui.rs
@@ -126,6 +126,11 @@ impl PlotUi {
         self.items.push(Box::new(item));
     }
 
+    /// Add an arbitrary item.
+    pub fn add_boxed(&mut self, item: Box<dyn PlotItem>) {
+        self.items.push(item);
+    }
+
     /// Add a data line.
     pub fn line(&mut self, mut line: crate::Line) {
         if line.series.is_empty() {

--- a/egui_plot/src/plot_ui.rs
+++ b/egui_plot/src/plot_ui.rs
@@ -127,7 +127,7 @@ impl PlotUi {
     }
 
     /// Add an arbitrary item.
-    pub fn add_boxed(&mut self, item: Box<dyn PlotItem>) {
+    pub fn add_item(&mut self, item: Box<dyn PlotItem>) {
         self.items.push(item);
     }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo for a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

* Closes <https://github.com/emilk/egui_plot/issues/53>
* [x] I have followed the instructions in the PR template

We have a somewhat unique setup in which we use dioxus for state management and egui for all of the underlying component rendering. When passing attributes through dioxus we have to cast the incoming type which requires that the trait objects be "object safe". `PlotItem` is not object safe, so we can't pass it through directly. But we also cannot pass in our own trait which has a method such as `fn as_egui_plot_item(&self) -> impl PlotItem` because that is also not object safe so instead we have a trait which has a method `fn as_egui_plot_item(&self) -> Box<dyn PlotItem>`. This cannot be passed to the existing `fn add(&self, impl PlotItem)` method because `Box<dyn PlotItem>` does not satisfy the `impl PlotItem` argument but since the `plot_items` are stored as `Vec<Box<dyn PlotItem>>` I've added this method to give access to insert directly.
