### PR TITLE
Fix axis thickness for multiple X or Y axes

### DIFF
--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -1343,6 +1343,12 @@ fn axis_widgets<'a>(
         }
     }
 
+    // The loops iterated through {x,y}_axes in reverse order, so we have to reverse the
+    // {x,y}_axis_widgets vec as well. Otherwise, the indices are messed up and the plot memory
+    // (mem.{x,y}_axis_thickness) will access the wrong axis given an index.
+    x_axis_widgets.reverse();
+    y_axis_widgets.reverse();
+
     let mut plot_rect = rect_left;
 
     // If too little space, remove axis widgets


### PR DESCRIPTION
Previously, the axis widgets and the plot memory would calculate conflicting thickness values for an axis because a reverse iterator was used to push the axis values.

Later, the axis thickness would be inserted using an index-based operation into plot memory, which did not take into account the reverse order.

See: `mem.y_axis_thickness.insert(i, thickness);`

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

Example code illustrating the issue:
```
use std::ops::RangeInclusive;

use eframe::egui;
use egui_plot::{AxisHints, GridMark, Legend, Line, Plot};

fn main() -> eframe::Result {
    let native_options = eframe::NativeOptions::default();
    eframe::run_native(
        "plotbug",
        native_options,
        Box::new(|cc| Ok(Box::new(App::new(cc)))),
    )
}

#[derive(Default)]
struct App {}

impl App {
    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
        // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
        // Restore app state using cc.storage (requires the "persistence" feature).
        // Use the cc.gl (a glow::Context) to create graphics shaders and buffers that you can use
        // for e.g. egui::PaintCallback.
        Self::default()
    }
}

impl eframe::App for App {
    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
        egui::CentralPanel::default().show(ctx, |ui| {
            let y_axis_formatter = |mark: GridMark, _range: &RangeInclusive<f64>| {
                format!("{} - and some very long text", mark.value)
            };

            let y_axes = vec![
                AxisHints::new_y()
                    .label("Y Axis Left")
                    .formatter(y_axis_formatter)
                    .placement(egui_plot::HPlacement::Left),
                AxisHints::new_y()
                    .label("Y Axis Right")
                    .placement(egui_plot::HPlacement::Right),
            ];

            let plot = Plot::new("plot")
                .show_grid(false)
                .custom_y_axes(y_axes)
                .legend(Legend::default());

            let _ = plot.show(ui, |plot_ui| {
                let points = [0.0, 1.0];
                plot_ui.line(Line::new(points.clone()));
            });
        });
    }
}
```

Before:
<img width="912" alt="before" src="https://github.com/user-attachments/assets/7961c648-f296-4936-b11e-ae3a2d7228c0" />

After:
<img width="912" alt="after" src="https://github.com/user-attachments/assets/1fafd05e-562e-41f9-b9b7-777271b9fbe2" />