### PR TITLE
Allow Plot::link_cursor to accept `impl Into<Vec2b>`

### DIFF
--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -587,8 +587,8 @@ impl<'a> Plot<'a> {
     /// Add this plot to a cursor link group so that this plot will share the cursor position with other plots
     /// in the same group. A plot cannot belong to more than one cursor group.
     #[inline]
-    pub fn link_cursor(mut self, group_id: impl Into<Id>, link: Vec2b) -> Self {
-        self.linked_cursors = Some((group_id.into(), link));
+    pub fn link_cursor(mut self, group_id: impl Into<Id>, link: impl Into<Vec2b>) -> Self {
+        self.linked_cursors = Some((group_id.into(), link.into()));
         self
     }
 


### PR DESCRIPTION
Updates the `link` argument to the `impl Into<Vec2b>` to be consistent with `link_axis`. This makes it slightly cleaner to use.

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

* [x] I have followed the instructions in the PR template
