### PR TITLE
axis: fix label thickness

### DIFF
--- a/egui_plot/src/axis.rs
+++ b/egui_plot/src/axis.rs
@@ -8,6 +8,9 @@ use egui::{
 
 use super::{transform::PlotTransform, GridMark};
 
+// Gap between tick labels and axis label in units of the axis label height
+const AXIS_LABEL_GAP: f32 = 0.25;
+
 pub(super) type AxisFormatterFn<'a> = dyn Fn(GridMark, &RangeInclusive<f64>) -> String + 'a;
 
 /// X or Y axis.
@@ -263,22 +266,19 @@ impl<'a> AxisWidget<'a> {
             TextStyle::Body,
         );
 
-        // Gap between tick labels and axis label in units of the axis label height
-        const GAP: f32 = 0.25;
-
         let text_pos = match self.hints.placement {
             Placement::LeftBottom => match axis {
                 Axis::X => {
                     let pos = response.rect.center_bottom();
                     Pos2 {
                         x: pos.x - galley.size().x * 0.5,
-                        y: pos.y - galley.size().y * (1.0 + GAP),
+                        y: pos.y - galley.size().y * (1.0 + AXIS_LABEL_GAP),
                     }
                 }
                 Axis::Y => {
                     let pos = response.rect.left_center();
                     Pos2 {
-                        x: pos.x - galley.size().y * GAP,
+                        x: pos.x - galley.size().y * AXIS_LABEL_GAP,
                         y: pos.y + galley.size().x * 0.5,
                     }
                 }
@@ -288,19 +288,19 @@ impl<'a> AxisWidget<'a> {
                     let pos = response.rect.center_top();
                     Pos2 {
                         x: pos.x - galley.size().x * 0.5,
-                        y: pos.y + galley.size().y * GAP,
+                        y: pos.y + galley.size().y * AXIS_LABEL_GAP,
                     }
                 }
                 Axis::Y => {
                     let pos = response.rect.right_center();
                     Pos2 {
-                        x: pos.x - galley.size().y * (1.0 - GAP),
+                        x: pos.x - galley.size().y * (1.0 - AXIS_LABEL_GAP),
                         y: pos.y + galley.size().x * 0.5,
                     }
                 }
             },
         };
-        let axis_label_thickness = galley.size().y * (1.0 + GAP);
+        let axis_label_thickness = galley.size().y * (1.0 + AXIS_LABEL_GAP);
         let angle = match axis {
             Axis::X => 0.0,
             Axis::Y => -std::f32::consts::FRAC_PI_2,

--- a/egui_plot/src/axis.rs
+++ b/egui_plot/src/axis.rs
@@ -254,80 +254,59 @@ impl<'a> AxisWidget<'a> {
         let Some(transform) = self.transform else {
             return (response, 0.0);
         };
-        let thickness = self.add_tick_labels(ui, transform, axis);
+        let labels_thickness = self.add_tick_labels(ui, transform, axis);
 
-        let visuals = ui.style().visuals.clone();
+        let galley = self.hints.label.into_galley(
+            ui,
+            Some(TextWrapMode::Extend),
+            f32::INFINITY,
+            TextStyle::Body,
+        );
 
-        let text_thickness = {
-            let text = self.hints.label;
-            let galley = text.into_galley(
-                ui,
-                Some(TextWrapMode::Extend),
-                f32::INFINITY,
-                TextStyle::Body,
-            );
-            let text_color = visuals
-                .override_text_color
-                .unwrap_or_else(|| ui.visuals().text_color());
-            let angle: f32 = match axis {
-                Axis::X => 0.0,
-                Axis::Y => -std::f32::consts::TAU * 0.25,
-            };
-            // select text_pos and angle depending on placement and orientation of widget
-            let (text_pos, text_thickness) = match self.hints.placement {
-                Placement::LeftBottom => match axis {
-                    Axis::X => {
-                        let pos = response.rect.center_bottom();
-                        (
-                            Pos2 {
-                                x: pos.x - galley.size().x / 2.0,
-                                y: pos.y - galley.size().y * 1.25,
-                            },
-                            0.0,
-                        )
+        let text_pos = match self.hints.placement {
+            Placement::LeftBottom => match axis {
+                Axis::X => {
+                    let pos = response.rect.center_bottom();
+                    Pos2 {
+                        x: pos.x - galley.size().x * 0.5,
+                        y: pos.y - galley.size().y * 1.25,
                     }
-                    Axis::Y => {
-                        let pos = response.rect.left_center();
-                        (
-                            Pos2 {
-                                x: pos.x,
-                                y: pos.y + galley.size().x / 2.0,
-                            },
-                            galley.size().x * 0.5,
-                        )
+                }
+                Axis::Y => {
+                    let pos = response.rect.left_center();
+                    Pos2 {
+                        x: pos.x - galley.size().y * 0.25,
+                        y: pos.y + galley.size().x * 0.5,
                     }
-                },
-                Placement::RightTop => match axis {
-                    Axis::X => {
-                        let pos = response.rect.center_top();
-                        (
-                            Pos2 {
-                                x: pos.x - galley.size().x / 2.0,
-                                y: pos.y + galley.size().y * 0.25,
-                            },
-                            0.0,
-                        )
+                }
+            },
+            Placement::RightTop => match axis {
+                Axis::X => {
+                    let pos = response.rect.center_top();
+                    Pos2 {
+                        x: pos.x - galley.size().x * 0.5,
+                        y: pos.y + galley.size().y * 0.25,
                     }
-                    Axis::Y => {
-                        let pos = response.rect.right_center();
-                        (
-                            Pos2 {
-                                x: pos.x - galley.size().y * 1.5,
-                                y: pos.y + galley.size().x / 2.0,
-                            },
-                            galley.size().x * 0.75,
-                        )
+                }
+                Axis::Y => {
+                    let pos = response.rect.right_center();
+                    Pos2 {
+                        x: pos.x - galley.size().y * 0.75,
+                        y: pos.y + galley.size().x * 0.5,
                     }
-                },
-            };
-
-            ui.painter()
-                .add(TextShape::new(text_pos, galley, text_color).with_angle(angle));
-
-            text_thickness
+                }
+            },
+        };
+        let text_thickness = galley.size().y;
+        let angle = match axis {
+            Axis::X => 0.0,
+            Axis::Y => -std::f32::consts::FRAC_PI_2,
         };
 
-        (response, thickness + text_thickness)
+        ui.painter()
+            .add(TextShape::new(text_pos, galley, ui.visuals().text_color()).with_angle(angle));
+
+        (response, labels_thickness + text_thickness)
     }
 
     /// Add tick labels to the axis. Returns the thickness of the axis.

--- a/egui_plot/src/axis.rs
+++ b/egui_plot/src/axis.rs
@@ -254,7 +254,7 @@ impl<'a> AxisWidget<'a> {
         let Some(transform) = self.transform else {
             return (response, 0.0);
         };
-        let labels_thickness = self.add_tick_labels(ui, transform, axis);
+        let tick_labels_thickness = self.add_tick_labels(ui, transform, axis);
 
         let galley = self.hints.label.into_galley(
             ui,
@@ -263,19 +263,22 @@ impl<'a> AxisWidget<'a> {
             TextStyle::Body,
         );
 
+        // Gap between tick labels and axis label in units of the axis label height
+        const GAP: f32 = 0.25;
+
         let text_pos = match self.hints.placement {
             Placement::LeftBottom => match axis {
                 Axis::X => {
                     let pos = response.rect.center_bottom();
                     Pos2 {
                         x: pos.x - galley.size().x * 0.5,
-                        y: pos.y - galley.size().y * 1.25,
+                        y: pos.y - galley.size().y * (1.0 + GAP),
                     }
                 }
                 Axis::Y => {
                     let pos = response.rect.left_center();
                     Pos2 {
-                        x: pos.x - galley.size().y * 0.25,
+                        x: pos.x - galley.size().y * GAP,
                         y: pos.y + galley.size().x * 0.5,
                     }
                 }
@@ -285,19 +288,19 @@ impl<'a> AxisWidget<'a> {
                     let pos = response.rect.center_top();
                     Pos2 {
                         x: pos.x - galley.size().x * 0.5,
-                        y: pos.y + galley.size().y * 0.25,
+                        y: pos.y + galley.size().y * GAP,
                     }
                 }
                 Axis::Y => {
                     let pos = response.rect.right_center();
                     Pos2 {
-                        x: pos.x - galley.size().y * 0.75,
+                        x: pos.x - galley.size().y * (1.0 - GAP),
                         y: pos.y + galley.size().x * 0.5,
                     }
                 }
             },
         };
-        let text_thickness = galley.size().y;
+        let axis_label_thickness = galley.size().y * (1.0 + GAP);
         let angle = match axis {
             Axis::X => 0.0,
             Axis::Y => -std::f32::consts::FRAC_PI_2,
@@ -306,7 +309,7 @@ impl<'a> AxisWidget<'a> {
         ui.painter()
             .add(TextShape::new(text_pos, galley, ui.visuals().text_color()).with_angle(angle));
 
-        (response, labels_thickness + text_thickness)
+        (response, tick_labels_thickness + axis_label_thickness)
     }
 
     /// Add tick labels to the axis. Returns the thickness of the axis.


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

When adding a bit longer axis labels it becomes clear that the Y axis label thickness is calculated wrong since https://github.com/emilk/egui_plot/pull/57. This fixes the computation.

Before (current main):
![image](https://github.com/user-attachments/assets/531b868b-5723-488a-b676-87b7dcfdf106)

After:
![image](https://github.com/user-attachments/assets/6d657f1e-ed3e-4124-92bc-2da665fd8815)


<!-- * Closes <https://github.com/emilk/egui_plot/issues/THE_RELEVANT_ISSUE> -->
* [x] I have followed the instructions in the PR template
