### PR TITLE
Fix include_{xy} issue when auto bounds is off

### DIFF
--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -983,10 +983,10 @@ impl<'a> Plot<'a> {
         }
 
         // Reset bounds to initial bounds if they haven't been modified.
-        if mem.auto_bounds.x {
+        if !default_auto_bounds.x || mem.auto_bounds.x {
             bounds.set_x(&min_auto_bounds);
         }
-        if mem.auto_bounds.y {
+        if !default_auto_bounds.y || mem.auto_bounds.y {
             bounds.set_y(&min_auto_bounds);
         }
 


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->
Re-open the following PR originally open by @aholtzma-am:
https://github.com/emilk/egui/pull/4539#issuecomment-2164776123

> The logic for determining bounds was not using the values supplied by include_x()/include_y() after the initial plot call when auto_bounds() was false. This change forces the use of the manual limits when default_auto_bounds is false.

Closes https://github.com/emilk/egui_plot/issues/25

I did not try the suggested approach (https://github.com/emilk/egui/pull/4539#issuecomment-2164776123), as I would need some more in-depth understanding before risking breaking other stuff.

Maybe, with some support, I could try to implement that approach in a separate PR.
