### PR TITLE
auto bounds X/Y indepented

### DIFF
--- a/egui_plot/src/transform.rs
+++ b/egui_plot/src/transform.rs
@@ -300,8 +300,8 @@ impl PlotTransform {
         } else if bounds.width() <= 0.0 {
             new_bounds.set_x_center_width(
                 bounds.center().x,
-                if bounds.is_valid_y() {
-                    bounds.height()
+                if bounds.is_valid_x() {
+                    bounds.width()
                 } else {
                     1.0
                 },
@@ -313,8 +313,8 @@ impl PlotTransform {
         } else if bounds.height() <= 0.0 {
             new_bounds.set_y_center_height(
                 bounds.center().y,
-                if bounds.is_valid_x() {
-                    bounds.width()
+                if bounds.is_valid_y() {
+                    bounds.height()
                 } else {
                     1.0
                 },


### PR DESCRIPTION
X and Y was link in autobound mode. 
problem example:
y  1.0 1.0 1.0
x 17777780000 17777880000 17777980000 (as timestamp in us) autobounds Y is 10000000

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

* Closes <https://github.com/emilk/egui_plot/issues/THE_RELEVANT_ISSUE>
* [ ] I have followed the instructions in the PR template
