### PR TITLE
Provide new functions to specify the default bounds

### DIFF
--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -501,6 +501,38 @@ impl<'a> Plot<'a> {
         self
     }
 
+    /// Overwrite the starting and reset bounds used for the x axis.
+    /// Set the `default_auto_bounds` of the x axis to `false`.
+    ///
+    /// Panic if the `min` is superior to the `max`.
+    #[inline]
+    pub fn default_x_bounds(mut self, min: f64, max: f64) -> Self {
+        assert!(
+            min < max,
+            "`min` must be inferior to `max` in `default_x_bounds`"
+        );
+        self.default_auto_bounds.x = false;
+        self.min_auto_bounds.min[0] = min;
+        self.min_auto_bounds.max[0] = max;
+        self
+    }
+
+    /// Overwrite the starting and reset bounds used for the y axis.
+    /// Set the `default_auto_bounds` of the y axis to `false`.
+    ///
+    /// Panic if the `min` is superior to the `max`.
+    #[inline]
+    pub fn default_y_bounds(mut self, min: f64, max: f64) -> Self {
+        assert!(
+            min < max,
+            "`min` must be inferior to `max` in `default_y_bounds`"
+        );
+        self.default_auto_bounds.y = false;
+        self.min_auto_bounds.min[1] = min;
+        self.min_auto_bounds.max[1] = max;
+        self
+    }
+
     /// Expand bounds to include the given x value.
     /// For instance, to always show the y axis, call `plot.include_x(0.0)`.
     #[inline]

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -520,12 +520,12 @@ impl<'a> Plot<'a> {
     /// Overwrite the starting and reset bounds used for the y axis.
     /// Set the `default_auto_bounds` of the y axis to `false`.
     ///
-    /// Panic if the `min` is superior to the `max`.
+    /// Panics in debug builds if `min >= max`.
     #[inline]
     pub fn default_y_bounds(mut self, min: f64, max: f64) -> Self {
-        assert!(
+        debug_assert!(
             min < max,
-            "`min` must be inferior to `max` in `default_y_bounds`"
+            "`min` must be less than `max` in `default_y_bounds`"
         );
         self.default_auto_bounds.y = false;
         self.min_auto_bounds.min[1] = min;

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -504,12 +504,12 @@ impl<'a> Plot<'a> {
     /// Overwrite the starting and reset bounds used for the x axis.
     /// Set the `default_auto_bounds` of the x axis to `false`.
     ///
-    /// Panic if the `min` is superior to the `max`.
+    /// Panics in debug builds if `min >= max`.
     #[inline]
     pub fn default_x_bounds(mut self, min: f64, max: f64) -> Self {
-        assert!(
+        debug_assert!(
             min < max,
-            "`min` must be inferior to `max` in `default_x_bounds`"
+            "`min` must be less than `max` in `default_x_bounds`"
         );
         self.default_auto_bounds.x = false;
         self.min_auto_bounds.min[0] = min;


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

* No associated issue
* [x] I have followed the instructions in the PR template

Hey,

I’ve been struggling for months with `egui_plot` because I’m displaying « a lot » of points (the temperature of the day of the past 20 years).
Here’s what it looks like currently when I open the window:
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/6f44a59d-c577-465b-99c6-40e108aa2d1d" />

It’s very hard to read and not very useful; usually, what I want to check is just the past months.
With this PR I’m able to set the starting view of my chart. 
That’s how it looks like if I only display the past two months, for example:
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/eeff7a3a-1526-4398-a885-647981e2ebe2" />


--------

If you want to see it running I deployed my website using this code [here](https://meteo.tamo.cool/).