### PR TITLE
 Fix BoxPlot legend and rename BoxPlot and BarChart `color` to `default_color`  

### DIFF
--- a/demo/src/plot_demo.rs
+++ b/demo/src/plot_demo.rs
@@ -976,7 +976,7 @@ impl ChartsDemo {
                 .map(|(x, f)| Bar::new(x, f * 10.0).width(0.1))
                 .collect(),
         )
-        .color(Color32::LIGHT_BLUE);
+        .default_color(Color32::LIGHT_BLUE);
 
         if !self.vertical {
             chart = chart.horizontal();

--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -1240,7 +1240,7 @@ pub struct BarChart {
     base: PlotItemBase,
 
     pub(super) bars: Vec<Bar>,
-    pub(super) default_color: Color32,
+    default_color: Color32,
 
     /// A custom element formatter
     pub(super) element_formatter: Option<Box<dyn Fn(&Bar, &BarChart) -> String>>,
@@ -1262,7 +1262,7 @@ impl BarChart {
     /// It can be overridden at the bar level (see [[`Bar`]]).
     /// Default is `Color32::TRANSPARENT` which means a color will be auto-assigned.
     #[inline]
-    pub fn color(mut self, color: impl Into<Color32>) -> Self {
+    pub fn default_color(mut self, color: impl Into<Color32>) -> Self {
         let plot_color = color.into();
         self.default_color = plot_color;
         for b in &mut self.bars {
@@ -1398,8 +1398,7 @@ pub struct BoxPlot {
     base: PlotItemBase,
 
     pub(super) boxes: Vec<BoxElem>,
-    pub(super) default_color: Color32,
-    pub(super) name: String,
+    default_color: Color32,
 
     /// A custom element formatter
     pub(super) element_formatter: Option<Box<dyn Fn(&BoxElem, &BoxPlot) -> String>>,
@@ -1412,7 +1411,6 @@ impl BoxPlot {
             base: PlotItemBase::new(name.into()),
             boxes,
             default_color: Color32::TRANSPARENT,
-            name: String::new(),
             element_formatter: None,
         }
     }
@@ -1422,7 +1420,7 @@ impl BoxPlot {
     /// It can be overridden at the element level (see [`BoxElem`]).
     /// Default is `Color32::TRANSPARENT` which means a color will be auto-assigned.
     #[inline]
-    pub fn color(mut self, color: impl Into<Color32>) -> Self {
+    pub fn default_color(mut self, color: impl Into<Color32>) -> Self {
         let plot_color = color.into();
         self.default_color = plot_color;
         for box_elem in &mut self.boxes {
@@ -1476,10 +1474,6 @@ impl PlotItem for BoxPlot {
 
     fn initialize(&mut self, _x_range: RangeInclusive<f64>) {
         // nothing to do
-    }
-
-    fn name(&self) -> &str {
-        self.name.as_str()
     }
 
     fn color(&self) -> Color32 {

--- a/egui_plot/src/plot_ui.rs
+++ b/egui_plot/src/plot_ui.rs
@@ -224,8 +224,8 @@ impl<'a> PlotUi<'a> {
         }
 
         // Give the elements an automatic color if no color has been assigned.
-        if box_plot.default_color == Color32::TRANSPARENT {
-            box_plot = box_plot.color(self.auto_color());
+        if box_plot.color() == Color32::TRANSPARENT {
+            box_plot = box_plot.default_color(self.auto_color());
         }
         self.items.push(Box::new(box_plot));
     }
@@ -237,8 +237,8 @@ impl<'a> PlotUi<'a> {
         }
 
         // Give the elements an automatic color if no color has been assigned.
-        if chart.default_color == Color32::TRANSPARENT {
-            chart = chart.color(self.auto_color());
+        if chart.color() == Color32::TRANSPARENT {
+            chart = chart.default_color(self.auto_color());
         }
         self.items.push(Box::new(chart));
     }


### PR DESCRIPTION
Fvg on discord noticed that BoxPlots were missing the legend. 

![Screenshot from 2025-04-07 23-16-30](https://github.com/user-attachments/assets/9ab9fbb6-5fb3-4683-899d-91b323e4bf60)


Upon further investigation, either some merge was a bit icky, or something was missed when adding in `PlotItemBase`. 

To fix this i have

  * **Replaced** `BoxPlot::color` with `BoxPlot::default_color`, as it was a name collision with `PlotItem::color`.
  * **Replaced** `BarChart::color` with `BarChart::default_color`, as it was a name collision with `PlotItem::color`.

 I know this is a breaking change without a deprication first, but i feel this is better than going for a deprication first.

  * Remove BoxPlots implementation of the `PlotItem::name()` function, and the `BoxPlot::name` field, as it was incomplete, and is also covered in `PlotItemBase`
  * Reduced the visibility of `BarChart::default_color` and `BoxPlot::default_color`, as it is only read, and only in `plot_ui.rs`, and that can be done via our newly not-name-colliding `PlotItem::color`. 

I also noticed there are missing snapshots for the (Charts.png is only the histogram, and only vertical). Barchart and boxplot are missing. But that is worth its own PR. 

In any case, with this, i get the expected legend back: 

![Screenshot from 2025-04-07 23-16-11](https://github.com/user-attachments/assets/24bde09d-5f59-4dff-be54-aad1de827fb0)


* [x] I have followed the instructions in the PR template
* [x] I have run `check.sh` locally and it went through. 