### PR TITLE
Add a background behind all text that is shown on hover

### DIFF
--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -1626,7 +1626,9 @@ fn add_rulers_and_text(
     });
 }
 
-/// Draws a cross of horizontal and vertical ruler at the `pointer` position.
+/// Draws a cross of horizontal and vertical ruler at the `pointer` position,
+/// and a label describing the coordinate.
+///
 /// `value` is used to for text displaying X/Y coordinates.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn rulers_at_value(
@@ -1672,16 +1674,16 @@ pub(super) fn rulers_at_value(
     };
 
     let font_id = TextStyle::Body.resolve(plot.ui.style());
-    plot.ui.fonts(|f| {
-        shapes.push(Shape::text(
-            f,
-            pointer + vec2(3.0, -2.0),
-            Align2::LEFT_BOTTOM,
-            text,
-            font_id,
-            plot.ui.visuals().text_color(),
-        ));
-    });
+    let ui = plot.ui;
+    let text_color = ui.visuals().text_color();
+    let galley = ui.fonts(|f| f.layout_no_wrap(text, font_id, text_color));
+    let rect = Align2::LEFT_BOTTOM.anchor_size(pointer + vec2(3.0, -2.0), galley.size());
+    shapes.push(Shape::rect_filled(
+        rect.expand(4.0),
+        ui.style().visuals.window_corner_radius,
+        ui.style().visuals.extreme_bg_color.gamma_multiply(0.75),
+    ));
+    shapes.push(Shape::galley(rect.min, galley, text_color));
 }
 
 fn find_closest_rect<'a, T>(

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -1678,6 +1678,7 @@ impl PreparedPlot<'_> {
         let painter = ui.painter().with_clip_rect(*transform.frame());
         painter.extend(shapes);
 
+        // Show coordinates in a corner of the plot:
         if let Some((corner, formatter)) = self.coordinates_formatter.as_ref() {
             let hover_pos = response.hover_pos();
             if let Some(pointer) = hover_pos {
@@ -1691,7 +1692,16 @@ impl PreparedPlot<'_> {
                     Corner::LeftBottom => (Align2::LEFT_BOTTOM, padded_frame.left_bottom()),
                     Corner::RightBottom => (Align2::RIGHT_BOTTOM, padded_frame.right_bottom()),
                 };
-                painter.text(position, anchor, text, font_id, ui.visuals().text_color());
+
+                let text_color = ui.visuals().text_color();
+                let galley = painter.layout_no_wrap(text, font_id, text_color);
+                let rect = anchor.anchor_size(position, galley.size());
+                painter.rect_filled(
+                    rect.expand(4.0),
+                    ui.style().visuals.window_corner_radius,
+                    ui.style().visuals.extreme_bg_color.gamma_multiply(0.75),
+                );
+                painter.galley(rect.min, galley, text_color);
             }
         }
 


### PR DESCRIPTION
This makes the text a lot more legible:

<img width="136" alt="Screenshot 2025-06-15 at 18 35 34" src="https://github.com/user-attachments/assets/618942ae-22b6-4c9f-a645-0538cfa0838d" />
<img width="224" alt="Screenshot 2025-06-15 at 18 35 28" src="https://github.com/user-attachments/assets/3bde7ce3-feda-44dd-9324-c268af45ea0b" />
