### PR TITLE
Draft: Adding rotation to text

### DIFF
--- a/demo/src/plot_demo.rs
+++ b/demo/src/plot_demo.rs
@@ -1,6 +1,6 @@
 use std::f64::consts::TAU;
 use std::ops::RangeInclusive;
-
+use eframe::emath::Align2;
 use egui::{
     Color32, ComboBox, NumExt as _, Pos2, Response, ScrollArea, Stroke, TextWrapMode, Vec2b,
     WidgetInfo, WidgetType, remap, vec2,
@@ -818,7 +818,12 @@ impl ItemsDemo {
             plot_ui.polygon(polygon.name("Convex polygon").id("convex_polygon"));
             plot_ui.points(points.name("Points with stems").id("points_with_stems"));
             plot_ui.text(Text::new("Text", PlotPoint::new(-3.0, -3.0), "wow").id("text0"));
-            plot_ui.text(Text::new("Text", PlotPoint::new(-2.0, 2.5), "so graph").id("text1"));
+            plot_ui.text(
+                Text::new("Text", PlotPoint::new(-2.0, 2.5), "so graph")
+                    .angle(-std::f32::consts::FRAC_PI_4)
+                    .anchor(Align2::CENTER_TOP)
+                    .id("text1")
+            );
             plot_ui.text(Text::new("Text", PlotPoint::new(3.0, 3.0), "much color").id("text2"));
             plot_ui.text(Text::new("Text", PlotPoint::new(2.5, -2.0), "such plot").id("text3"));
             plot_ui.image(image.name("Image"));

--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -656,6 +656,7 @@ pub struct Text {
     pub(super) position: PlotPoint,
     pub(super) color: Color32,
     pub(super) anchor: Align2,
+    pub(super) angle: f32,
 }
 
 impl Text {
@@ -666,6 +667,7 @@ impl Text {
             position,
             color: Color32::TRANSPARENT,
             anchor: Align2::CENTER_CENTER,
+            angle: 0.0,
         }
     }
 
@@ -673,6 +675,13 @@ impl Text {
     #[inline]
     pub fn color(mut self, color: impl Into<Color32>) -> Self {
         self.color = color.into();
+        self
+    }
+
+    /// Text rotation angle.
+    #[inline]
+    pub fn angle(mut self, angle: f32) -> Self {
+        self.angle = angle;
         self
     }
 
@@ -704,7 +713,7 @@ impl PlotItem for Text {
         let pos = transform.position_from_point(&self.position);
         let rect = self.anchor.anchor_size(pos, galley.size());
 
-        shapes.push(TextShape::new(rect.min, galley, color).into());
+        shapes.push(TextShape::new(rect.min, galley, color).with_angle(self.angle).into());
 
         if self.base.highlight {
             shapes.push(Shape::rect_stroke(


### PR DESCRIPTION
Adding ability to specify rotation angle for `Text` instances.

![image](https://github.com/user-attachments/assets/a8a1573c-0d37-4ed6-ad01-8c10f1e6baa8)

* [x] I have followed the instructions in the PR template
