### PR TITLE
Add the ability invert the X and/or Y axis

### DIFF
--- a/demo/tests/snapshots/demos/Items.png
+++ b/demo/tests/snapshots/demos/Items.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ee406b49e1dc5a08e5c232ad88a23db865dbb6f1d5713d323dd223509f2dc13
-size 108580
+oid sha256:841c4b768210e3594ddcac91627d0b7e876d1fbbd1bc5eb8bc12808dc4910572
+size 107781

--- a/demo/tests/snapshots/demos/Linked Axes.png
+++ b/demo/tests/snapshots/demos/Linked Axes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4dddc7e699b300572b3e7169d3064b5be20f1a22e0ae8c75e964bf56fd49986c
-size 82691
+oid sha256:8172eb44df3ccfad31c5bce48417415c871eda4d7b1d50b1f39b53d6d44db373
+size 82799

--- a/demo/tests/snapshots/light_mode.png
+++ b/demo/tests/snapshots/light_mode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25ef03d10d3be0e1091834ff82cd7818b5bc8cf3468312001fb0c7fe57703a97
-size 113646
+oid sha256:df70502f3f30df6b6ab6077b5fcb9c379ef9469f5c6f59312161e3bb17422e64
+size 113695

--- a/demo/tests/snapshots/scale_1.39.png
+++ b/demo/tests/snapshots/scale_1.39.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac088ec542cfa28943f5959e502fb9164954c746674dd383e7e83d23e62d9988
-size 220888
+oid sha256:a64bd11d7a5fb30f78e0663214e9ade657e98fbecb8918cff651d8a75f08aeea
+size 217546

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -173,6 +173,8 @@ pub struct Plot<'a> {
     height: Option<f32>,
     data_aspect: Option<f32>,
     view_aspect: Option<f32>,
+    invert_x: bool,
+    invert_y: bool,
 
     reset: bool,
 
@@ -221,6 +223,8 @@ impl<'a> Plot<'a> {
             height: None,
             data_aspect: None,
             view_aspect: None,
+            invert_x: false,
+            invert_y: false,
 
             reset: false,
 
@@ -270,6 +274,22 @@ impl<'a> Plot<'a> {
     #[inline]
     pub fn view_aspect(mut self, view_aspect: f32) -> Self {
         self.view_aspect = Some(view_aspect);
+        self
+    }
+
+    /// Set whether to invert the x-axis (i.e. positive values go to the left).
+    /// By default the x-axis is not inverted (i.e. positive values go to the right).
+    #[inline]
+    pub fn invert_x(mut self, invert: bool) -> Self {
+        self.invert_x = invert;
+        self
+    }
+
+    /// Set whether to invert the y-axis (i.e. positive values go down).
+    /// By default the y-axis is not inverted (i.e. positive values go up).
+    #[inline]
+    pub fn invert_y(mut self, invert: bool) -> Self {
+        self.invert_y = invert;
         self
     }
 
@@ -803,6 +823,8 @@ impl<'a> Plot<'a> {
             mut min_size,
             data_aspect,
             view_aspect,
+            invert_x,
+            invert_y,
             mut show_x,
             mut show_y,
             label_formatter,
@@ -920,7 +942,12 @@ impl<'a> Plot<'a> {
             auto_bounds: default_auto_bounds,
             hovered_legend_item: None,
             hidden_items: Default::default(),
-            transform: PlotTransform::new(plot_rect, min_auto_bounds, center_axis),
+            transform: PlotTransform::new_with_invert_axis(
+                plot_rect,
+                min_auto_bounds,
+                center_axis,
+                Vec2b::new(invert_x, invert_y),
+            ),
             last_click_pos_for_zoom: None,
             x_axis_thickness: Default::default(),
             y_axis_thickness: Default::default(),
@@ -1094,7 +1121,12 @@ impl<'a> Plot<'a> {
             }
         }
 
-        mem.transform = PlotTransform::new(plot_rect, bounds, center_axis);
+        mem.transform = PlotTransform::new_with_invert_axis(
+            plot_rect,
+            bounds,
+            center_axis,
+            Vec2b::new(invert_x, invert_y),
+        );
 
         // Enforce aspect ratio
         if let Some(data_aspect) = data_aspect {

--- a/examples/custom_plot_manipulation/src/main.rs
+++ b/examples/custom_plot_manipulation/src/main.rs
@@ -81,6 +81,8 @@ impl eframe::App for PlotExample {
                 .allow_zoom(false)
                 .allow_drag(false)
                 .allow_scroll(false)
+                .invert_x(false)
+                .invert_y(true)
                 .legend(Legend::default())
                 .show(ui, |plot_ui| {
                     if let Some(mut scroll) = scroll {


### PR DESCRIPTION
By "invert" I mean to change the default direction of the axis. The standard convention for plots is for +X to go to the right and +Y to go up. In some scenarios, particularly working with images or camera coordinates, +Y should point down.

There's already an existing strategy for inverting the Y axis in the `PlotTransform` struct, since screen coordinates have +Y pointing down and plots conventionally have +Y pointing up. That strategy was expanded upon and made configurable from `Plot`.

A few questions:
- I avoided breaking `PlotTransform::new` by providing `PlotTransform::new_with_invert_axis` which is a bit cumbersome to write out. Would we rather break the API by just adding a parameter to `new`?
- I didn't expect there to be any differences from the test snapshot, but there were several small ones. Most of the changes can't really be seen, though there are a few pixels with apparent differences. I don't know if this is just platform differences. The code changes are simple enough that for the not-inverted case, I don't see how anything really out to change. Assuming these are just platform differences, is the convention to update the screenshots or leave it?


* Closes <https://github.com/emilk/egui_plot/issues/21>
* [x] I have followed the instructions in the PR template
