### PR TITLE
Hide coordinate's tooltip if label is empty

### DIFF
--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -1718,7 +1718,11 @@ pub(super) fn rulers_and_tooltip_at_value(
     }
 
     let text = if let Some(custom_label) = label_formatter {
-        custom_label(name, &value)
+        let label = custom_label(name, &value);
+        if label.is_empty() {
+            return;
+        }
+        label
     } else {
         let prefix = if name.is_empty() {
             String::new()


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

Hi, I noticed that there was no way to hide a coordinate’s tooltip based on certain conditions, so I made it skip showing the tooltip when the label is empty.

Alternatively, we could make this behavior clearer by changing the `LabelFormatterFn` return type from `String + 'a `to `Option<String> + 'a`, if a breaking change is acceptable.

https://github.com/user-attachments/assets/ca661707-7d14-4102-9e0c-933ddc161170

