### PR TITLE
Change `PreparedPlot::hover` to use last suitable `PlotItem`

### DIFF
--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -1859,7 +1859,10 @@ impl PreparedPlot<'_> {
                 Some(item).zip(closest)
             });
 
-        let closest = candidates
+        // Since many items can have same distance,
+        // and dist_sq can be zero for some items (e.g. rectangle)
+        // we pick topmost item within interact radius
+        let topmost = candidates
             .filter(|(_, elem)| elem.dist_sq <= interact_radius_sq)
             .next_back();
 
@@ -1872,7 +1875,7 @@ impl PreparedPlot<'_> {
 
         let mut cursors = Vec::new();
 
-        let hovered_plot_item_id = if let Some((item, elem)) = closest {
+        let hovered_plot_item_id = if let Some((item, elem)) = topmost {
             item.on_hover(
                 plot_area_response,
                 elem,


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->
Currently, `PreparedPlot::hover` always selects the item with the smallest `dist_sq`, which causes incorrect tooltip behavior when multiple items overlap.

For example:
1. A rectangle always captures hover because its `dist_sq` is 0, even when points are drawn on top of it.
2. Lines and points have inverse hover order (hover info is shown for the first drawn item).

This change updates the hover selection logic to prefer later-drawn (visually topmost) items when multiple elements are within interactive range.

Before change:

https://github.com/user-attachments/assets/2f046d81-25f1-4c7b-aa73-0b47279e777b

After change:

https://github.com/user-attachments/assets/3407c5c3-dc28-4afa-84f8-3031a7cd19f0

* Closes #4 (kinda, hover priority will follow order of items)
