### PR TITLE
Add ability to specify color and font of axis tick labels for each axis

### DIFF
--- a/egui_plot/src/axis.rs
+++ b/egui_plot/src/axis.rs
@@ -23,7 +23,6 @@ use emath::remap;
 
 use crate::bounds::PlotBounds;
 use crate::bounds::PlotPoint;
-use crate::colors;
 use crate::grid::GridMark;
 use crate::placement::HPlacement;
 use crate::placement::Placement;
@@ -300,11 +299,7 @@ impl<'a> AxisWidget<'a> {
                     super::color_from_strength(ui, strength)
                 };
 
-                let label_font_id = self
-                    .hints
-                    .tick_label_font
-                    .clone()
-                    .unwrap_or_else(|| font_id.clone());
+                let label_font_id = self.hints.tick_label_font.clone().unwrap_or_else(|| font_id.clone());
 
                 let galley = painter.layout_no_wrap(text, label_font_id, text_color);
                 let galley_size = match axis {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

This allows specifying the color and font (through FontId) of the tick labels for each axis on a plot
<img width="1329" height="867" alt="image" src="https://github.com/user-attachments/assets/a5e683e4-0163-40d4-8955-0ca106ec12d0" />

All feedback and criticism of the API and implementation are much appreciated. I will note, to ensure that the fading of the tick label color is respected, I did the following

```
let text_color = if let Some(color) = self.hints.tick_label_color {
    color.gamma_multiply(strength.sqrt())
} else {
    super::color_from_strength(ui, strength)
};
```
and I don't love the duplication of the gamma_multiply, I just didn't want to touch the color_from_strength function without the all clear.


* Closes <https://github.com/emilk/egui_plot/issues/154>
* [x] I have followed the instructions in the PR template