### PR TITLE
Include all png files in the snapshot results

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -147,4 +147,4 @@ jobs:
         if: always()
         with:
           name: test-results
-          path: "**/tests/snapshots"
+          path: "*.png"


### PR DESCRIPTION
This should fix reviewing test runs in kitdiff