### PR TITLE
Fix no auto_bounds preventing pan/zoom/scroll

### DIFF
--- a/egui_plot/src/plot.rs
+++ b/egui_plot/src/plot.rs
@@ -977,7 +977,6 @@ impl<'a> Plot<'a> {
             mem.auto_bounds = true.into();
         }
 
-        let any_dynamic_modifications = !plot_ui.bounds_modifications.is_empty();
         // Apply bounds modifications.
         for modification in &plot_ui.bounds_modifications {
             match modification {
@@ -1006,11 +1005,11 @@ impl<'a> Plot<'a> {
             }
         }
 
-        // Reset bounds to initial bounds if they haven't been modified.
-        if (!self.default_auto_bounds.x && !any_dynamic_modifications) || mem.auto_bounds.x {
+        // Reset bounds to initial bounds if current auto_bounds are active.
+        if mem.auto_bounds.x {
             bounds.set_x(&self.min_auto_bounds);
         }
-        if (!self.default_auto_bounds.y && !any_dynamic_modifications) || mem.auto_bounds.y {
+        if mem.auto_bounds.y {
             bounds.set_y(&self.min_auto_bounds);
         }
 


### PR DESCRIPTION
The previous logic would force reset the bounds for an axis if its auto_bounds was false. I believe that the behavior of mem.auto_bounds already sufficiently achieves the intended behavior here.

Scenarios tested:
- User can pan/zoom/scroll with auto_bounds true/false
- Double-click resets auto_bounds the plot (regardless of default_auto_bounds setting)
- Plot bounds are updated when plot data changes after double-clicking
- User can still interact with the plot (pan/zoom/scroll) after double-clicking

<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->



* Closes #151
* [x] I have followed the instructions in the PR template
