### PR TITLE
Fix broken relative README links on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Immediate mode 2D plotting library for [`egui`](https://crates.io/crates/https:/
 
 ## Plotting libraries in Rust
 
-To view a list of plotting libraries in Rust, see [notes on Rust plotting ecosystem](ECOSYSTEM.md).
+To view a list of plotting libraries in Rust, see [notes on Rust plotting ecosystem](https://github.com/emilk/egui_plot/blob/main/ECOSYSTEM.md).
 
 ## Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) and [WELCOME_CONTRIBUTIONS.md](WELCOME_CONTRIBUTIONS.md)
+Please see [CONTRIBUTING.md](https://github.com/emilk/egui_plot/blob/main/CONTRIBUTING.md) and [WELCOME_CONTRIBUTIONS.md](https://github.com/emilk/egui_plot/blob/main/WELCOME_CONTRIBUTIONS.md)
 
 ## History
 


### PR DESCRIPTION
The README is published to crates.io from the repo root (`readme = "../README.md"` in `egui_plot/Cargo.toml`), but crates.io resolves relative links against the crate's manifest directory (`egui_plot/`) instead of the README's actual location. That injects an extra `egui_plot/` path segment, so the links 404 on the crate page.

Links as rendered on crates.io today (all 404):
- `ECOSYSTEM.md` -> `.../blob/HEAD/egui_plot/ECOSYSTEM.md`
- `CONTRIBUTING.md` -> `.../blob/HEAD/egui_plot/CONTRIBUTING.md`
- `WELCOME_CONTRIBUTIONS.md` -> `.../blob/HEAD/egui_plot/WELCOME_CONTRIBUTIONS.md`

Fix: use absolute `https://github.com/emilk/egui_plot/blob/main/<file>` URLs, which resolve on both crates.io and GitHub (all return 200). Rendering on GitHub is unchanged.

* [x] I have followed the instructions in the PR template