### PR TITLE
Replace `impl Into<f32>` parameters with just `f32`

### DIFF
--- a/egui_plot/src/items/line.rs
+++ b/egui_plot/src/items/line.rs
@@ -45,8 +45,8 @@ impl HLine {
 
     /// Stroke width. A high value means the plot thickens.
     #[inline]
-    pub fn width(mut self, width: impl Into<f32>) -> Self {
-        self.stroke.width = width.into();
+    pub fn width(mut self, width: f32) -> Self {
+        self.stroke.width = width;
         self
     }
 
@@ -180,8 +180,8 @@ impl VLine {
 
     /// Stroke width. A high value means the plot thickens.
     #[inline]
-    pub fn width(mut self, width: impl Into<f32>) -> Self {
-        self.stroke.width = width.into();
+    pub fn width(mut self, width: f32) -> Self {
+        self.stroke.width = width;
         self
     }
 

--- a/egui_plot/src/items/points.rs
+++ b/egui_plot/src/items/points.rs
@@ -56,15 +56,15 @@ impl<'a> Points<'a> {
     /// Whether to add stems between the markers and a horizontal reference
     /// line.
     #[inline]
-    pub fn stems(mut self, y_reference: impl Into<f32>) -> Self {
-        self.stems = Some(y_reference.into());
+    pub fn stems(mut self, y_reference: f32) -> Self {
+        self.stems = Some(y_reference);
         self
     }
 
     /// Set the maximum extent of the marker around its position, in ui points.
     #[inline]
-    pub fn radius(mut self, radius: impl Into<f32>) -> Self {
-        self.radius = radius.into();
+    pub fn radius(mut self, radius: f32) -> Self {
+        self.radius = radius;
         self
     }
 

--- a/egui_plot/src/items/polygon.rs
+++ b/egui_plot/src/items/polygon.rs
@@ -45,8 +45,8 @@ impl<'a> Polygon<'a> {
 
     /// Set the stroke width.
     #[inline]
-    pub fn width(mut self, width: impl Into<f32>) -> Self {
-        self.stroke.width = width.into();
+    pub fn width(mut self, width: f32) -> Self {
+        self.stroke.width = width;
         self
     }
 

--- a/egui_plot/src/items/series.rs
+++ b/egui_plot/src/items/series.rs
@@ -81,8 +81,8 @@ impl<'a> Line<'a> {
 
     /// Stroke width. A high value means the plot thickens.
     #[inline]
-    pub fn width(mut self, width: impl Into<f32>) -> Self {
-        self.stroke.width = width.into();
+    pub fn width(mut self, width: f32) -> Self {
+        self.stroke.width = width;
         self
     }
 
@@ -96,15 +96,15 @@ impl<'a> Line<'a> {
 
     /// Fill the area between this line and a given horizontal reference line.
     #[inline]
-    pub fn fill(mut self, y_reference: impl Into<f32>) -> Self {
-        self.fill = Some(y_reference.into());
+    pub fn fill(mut self, y_reference: f32) -> Self {
+        self.fill = Some(y_reference);
         self
     }
 
     /// Set the fill area's alpha channel. Default is `0.05`.
     #[inline]
-    pub fn fill_alpha(mut self, alpha: impl Into<f32>) -> Self {
-        self.fill_alpha = alpha.into();
+    pub fn fill_alpha(mut self, alpha: f32) -> Self {
+        self.fill_alpha = alpha;
         self
     }
 

--- a/egui_plot/src/items/span.rs
+++ b/egui_plot/src/items/span.rs
@@ -96,8 +96,8 @@ impl Span {
 
     /// Convenience for updating the span border width.
     #[inline]
-    pub fn border_width(mut self, width: impl Into<f32>) -> Self {
-        self.border_stroke.width = width.into();
+    pub fn border_width(mut self, width: f32) -> Self {
+        self.border_stroke.width = width;
         self
     }
 


### PR DESCRIPTION
These produce warnings on `nightly`, and maybe on future stable versions of the compiler