### PR TITLE
Determine position of plot based on layout direction

### DIFF
--- a/egui_plot/src/plot.rs
+++ b/egui_plot/src/plot.rs
@@ -812,8 +812,6 @@ impl<'a> Plot<'a> {
 
     /// Calculate the rect inside which everything will be drawn.
     fn calculate_widget_complete_rect(&self, ui: &Ui) -> Rect {
-        // Determine position of widget.
-        let pos = ui.available_rect_before_wrap().min;
         // Minimum values for screen protection
         let mut min_size = self.min_size;
         min_size.x = min_size.x.at_least(1.0);
@@ -845,11 +843,27 @@ impl<'a> Plot<'a> {
             vec2(width, height)
         };
 
-        // Determine complete rect of widget.
-        Rect {
-            min: pos,
-            max: pos + size,
-        }
+        // Determine position of widget, anchored to whichever corner the
+        // current layout direction actually grows from. `available_rect_before_wrap`
+        // only reports the true cursor position on the edge matching `main_dir`
+        // (e.g. for `BottomUp` layouts that's `.max.y`, not `.min.y`), so blindly
+        // using `.min` as the origin places the widget in the wrong corner and
+        // makes successive widgets overlap (#237).
+        let avail = ui.available_rect_before_wrap();
+        let main_dir = ui.layout().main_dir();
+
+        let (min_x, max_x) = if main_dir == egui::Direction::RightToLeft {
+            (avail.max.x - size.x, avail.max.x)
+        } else {
+            (avail.min.x, avail.min.x + size.x)
+        };
+        let (min_y, max_y) = if main_dir == egui::Direction::BottomUp {
+            (avail.max.y - size.y, avail.max.y)
+        } else {
+            (avail.min.y, avail.min.y + size.y)
+        };
+
+        Rect::from_min_max(emath::pos2(min_x, min_y), emath::pos2(max_x, max_y))
     }
 
     fn allocate_axis_responses(&self, ui: &mut Ui, axis_widgets: &AxisWidgets<'_>) -> AxisResponses {


### PR DESCRIPTION
<!--
Please read the "Making a PR" section of [`CONTRIBUTING.md`](https://github.com/emilk/egui_plot/blob/master/CONTRIBUTING.md) before opening a Pull Request!

* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* If it is a non-trivial addition, consider adding a demo f or a new example.
* Do NOT open PR:s from your `master` or `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and run `./scripts/check.sh`.
* When you have addressed a PR comment, mark it as resolved.

Please be patient! We will review your PR, but our time is limited!
-->

* Closes <https://github.com/emilk/egui_plot/issues/237>
* [X] I have followed the instructions in the PR template

The layout is now respected when `egui_plot` attempts to calculate available rect and anchor position for plots